### PR TITLE
Fix tooltip UI

### DIFF
--- a/BashGuiHelper.cpp
+++ b/BashGuiHelper.cpp
@@ -168,8 +168,8 @@ public:
     int handle(int event) {
         HTreeItem *it = NULL;
         int rc;
-        auto reason = callback_reason();
-        if (reason == FL_TREE_REASON_OPENED || reason == FL_TREE_REASON_CLOSED) return Fl_Tree::handle(event);
+        // auto reason = callback_reason();
+        // if (reason == FL_TREE_REASON_OPENED || reason == FL_TREE_REASON_CLOSED) return Fl_Tree::handle(event);
         switch(event) {
             case FL_NO_EVENT:
                 break;


### PR DESCRIPTION
Disable callback check since after click expand widget it keep status so we can't process event like normal